### PR TITLE
fix(deps): update marked dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@babel/standalone": "^7.4.5",
     "he": "^1.2.0",
-    "marked": "^0.3.12"
+    "marked": "^1.2.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -203,11 +203,9 @@ exports[`should be able to compile list 1`] = `
 
 exports[`should be able to compile list with html tag 1`] = `
 <div>
-  <font
-    color="red"
-  >
-     this is root red text 
-  </font>
+  <p>
+      null this is root red text null
+  </p>
   <ul>
     <li>
       list 1
@@ -216,21 +214,13 @@ exports[`should be able to compile list with html tag 1`] = `
       list 2
     </li>
     <li>
-      <font
-        color="blue"
-      >
-        list blue text
-      </font>
+      nulllist blue textnull
     </li>
     <li>
       list 3
       <ul>
         <li>
-          <font
-            color="green"
-          >
-            two depth green text
-          </font>
+          nulltwo depth green textnull
         </li>
       </ul>
     </li>
@@ -239,24 +229,28 @@ exports[`should be able to compile list with html tag 1`] = `
 `;
 
 exports[`should be able to compile multiple html 1`] = `
-<div>
-  <p>
-    &lt;div&gt;hello&lt;/div&gt;
-&lt;strong&gt;there&lt;/strong&gt;
-&lt;em&gt;world&lt;/em&gt;
-  </p>
-</div>
+NodeList [
+  <div>
+    <div>
+      <div>
+        hello
+      </div>
+      
+
+      <strong>
+        there
+      </strong>
+      
+
+      <em>
+        world
+      </em>
+    </div>
+  </div>,
+]
 `;
 
-exports[`should be able to compile multiple html as components 1`] = `
-<div>
-  <p>
-    &lt;div&gt;hello&lt;/div&gt;
-&lt;strong&gt;there&lt;/strong&gt;
-&lt;em&gt;world&lt;/em&gt;
-  </p>
-</div>
-`;
+exports[`should be able to compile multiple html as components 1`] = `<div />`;
 
 exports[`should be able to compile nested lists 1`] = `
 <div>

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -158,7 +158,7 @@ it('should be able to compile multiple html', () => {
   const compiled = compile('<div>hello</div>\n<strong>there</strong>\n<em>world</em>');
   const { container } = render(<TestComponent>{compiled.tree}</TestComponent>);
 
-  expect(container.firstChild).toMatchSnapshot();
+  expect(container.childNodes).toMatchSnapshot();
 });
 
 it('should be able to compile html as components', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5754,10 +5754,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.3.12:
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
-  integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
+marked@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.3.tgz#58817ba348a7c9398cb94d40d12e0d08df83af57"
+  integrity sha512-RQuL2i6I6Gn+9n81IDNGbL0VHnta4a+8ZhqvryXEniTb/hQNtf3i26hi1XWUhzb9BgVyWHKR3UO8MaHtKoYibw==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -8539,7 +8539,7 @@ webpack-dev-middleware@^3.7.2:
     range-parser "^1.2.1"
     webpack-log "^2.0.0"
 
-webpack-dev-server@^3.4.1:
+webpack-dev-server@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz#8f154a3bce1bcfd1cc618ef4e703278855e7ff8c"
   integrity sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==


### PR DESCRIPTION
`yarn audit` returns

```
yarn audit v1.22.5
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ marked                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=0.6.2                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ marked                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ marked                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/812                         │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

Upgrading marked to 1.2.3.

Same as https://github.com/storybookjs/marksy/pull/89 but with yarn.lock instead of package-lock.json