### PR TITLE
Upgrade marked to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@babel/standalone": "^7.4.5",
     "he": "^1.2.0",
-    "marked": "^1.2.3"
+    "marked": "^4.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -72,6 +72,7 @@ exports[`should be able to combine in compilation 1`] = `
   </ul>
   <p>
     -bar
+  
   </p>
 </div>
 `;
@@ -309,7 +310,7 @@ exports[`should be able to compile self-closing tag 1`] = `
       <br />
     </div>
     
-
+  
 
   </div>
   <div>
@@ -325,7 +326,7 @@ exports[`should be able to compile self-closing tag 1`] = `
       type="text"
     />
     
-
+  
   </div>
 </div>
 `;

--- a/src/createRenderer.js
+++ b/src/createRenderer.js
@@ -1,4 +1,4 @@
-import marked from 'marked';
+import { Renderer } from 'marked';
 import he from 'he';
 
 export function codeRenderer(tracker, options) {
@@ -42,7 +42,7 @@ export function codeRenderer(tracker, options) {
 }
 
 export default function createRenderer(tracker, options, overrides = {}) {
-  const renderer = new marked.Renderer();
+  const renderer = new Renderer();
 
   function getTocPosition(toc, level) {
     let currentLevel = toc.children;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import marked from 'marked';
+import { marked } from 'marked';
 import createRenderer, { codeRenderer } from './createRenderer';
 
 export function marksy(options = {}) {

--- a/src/jsx.js
+++ b/src/jsx.js
@@ -1,4 +1,4 @@
-import marked from 'marked';
+import { marked } from 'marked';
 import { transform } from '@babel/standalone';
 import createRenderer, { codeRenderer } from './createRenderer';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5981,10 +5981,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.3.tgz#58817ba348a7c9398cb94d40d12e0d08df83af57"
-  integrity sha512-RQuL2i6I6Gn+9n81IDNGbL0VHnta4a+8ZhqvryXEniTb/hQNtf3i26hi1XWUhzb9BgVyWHKR3UO8MaHtKoYibw==
+marked@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
Due to the fact that this PR https://github.com/storybookjs/marksy/pull/336 has been open since 2022, I fixed all tests and completed a full upgrade

@Hypnosphi 